### PR TITLE
Auth support on acng-report.html page

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -37,6 +37,7 @@ class acng::server (
   }
 
   file { '/etc/apt-cacher-ng/security.conf':
+    notify  => Service["apt-cacher-ng"],
     ensure  => $ensure,
     owner   => 'root',
     group   => 'apt-cacher-ng',

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -13,7 +13,9 @@
 #
 class acng::server (
   $ensure = 'present',
-  $enable = true
+  $enable = true,
+  $admin_user = undef,
+  $admin_pass = undef
 ) {
 
   package { 'apt-cacher-ng':
@@ -34,4 +36,11 @@ class acng::server (
     require    => Package['apt-cacher-ng'],
   }
 
+  file { '/etc/apt-cacher-ng/security.conf':
+    ensure  => $ensure,
+    owner   => 'root',
+    group   => 'apt-cacher-ng',
+    mode    => '0640',
+    content => "AdminAuth: ${admin_user}:${admin_pass}\n",
+  }
 }


### PR DESCRIPTION
Adds authentication support on the admin page. Tested on puppet 3.8.3, with hiera.